### PR TITLE
ファイルパーミッションを変更

### DIFF
--- a/srlogrotate.go
+++ b/srlogrotate.go
@@ -112,7 +112,7 @@ func (l *logger) openNew() error {
 	}
 
 	name := l.fileName()
-	mode := os.FileMode(0600)
+	mode := os.FileMode(0644)
 	info, err := os.Stat(name)
 	if err == nil {
 		mode = info.Mode()


### PR DESCRIPTION
出力ログのファイルパーミッションが600であった。644にして他のユーザでも閲覧のみできるようにする。